### PR TITLE
feat: API client error handling and toast notifications

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,9 +1,9 @@
-import js from '@eslint/js'
-import globals from 'globals'
-import reactHooks from 'eslint-plugin-react-hooks'
-import reactRefresh from 'eslint-plugin-react-refresh'
-import tseslint from 'typescript-eslint'
-import { defineConfig, globalIgnores } from 'eslint/config'
+import js from '@eslint/js';
+import globals from 'globals';
+import reactHooks from 'eslint-plugin-react-hooks';
+import reactRefresh from 'eslint-plugin-react-refresh';
+import tseslint from 'typescript-eslint';
+import { defineConfig, globalIgnores } from 'eslint/config';
 
 export default defineConfig([
   globalIgnores(['dist']),
@@ -19,5 +19,11 @@ export default defineConfig([
       ecmaVersion: 2020,
       globals: globals.browser,
     },
+    rules: {
+      'react-refresh/only-export-components': [
+        'warn',
+        { allowExportNames: ['badgeVariants', 'buttonVariants'] },
+      ],
+    },
   },
-])
+]);

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -1,28 +1,47 @@
 import axios from 'axios';
+import { toast } from 'sonner';
+import { getErrorMessage } from '@/lib/api-utils';
 
 const apiClient = axios.create({
-    baseURL: import.meta.env.VITE_API_BASE_URL,
-    withCredentials: true,
-    headers: { 'Content-Type': 'application/json' },
+  baseURL: import.meta.env.VITE_API_BASE_URL,
+  withCredentials: true,
+  timeout: 15000,
+  headers: { 'Content-Type': 'application/json' },
 });
 
 apiClient.interceptors.request.use((config) => {
-    const token = localStorage.getItem('authToken');
-    if (token) {
-        config.headers.Authorization = `Bearer ${token}`;
-    }
-    return config;
+  const token = localStorage.getItem('authToken');
+  if (token) {
+    config.headers.Authorization = `Bearer ${token}`;
+  }
+  return config;
 });
 
 apiClient.interceptors.response.use(
-    (response) => response,
-    (error) => {
-        if (error.response?.status === 401) {
-            localStorage.removeItem('authToken');
-            window.location.href = '/login';
-        }
-        return Promise.reject(error);
-    },
+  (response) => response,
+  (error) => {
+    if (!axios.isAxiosError(error)) return Promise.reject(error);
+
+    const status = error.response?.status;
+    const isAuthEndpoint = error.config?.url?.startsWith('/auth/');
+
+    // 401 on protected endpoints → session expired, redirect
+    if (status === 401 && !isAuthEndpoint) {
+      localStorage.removeItem('authToken');
+      window.location.href = '/login';
+      return Promise.reject(error);
+    }
+
+    // 400 → validation error, let the form handle it (no toast)
+    // 401 on /auth/* → wrong credentials, let the form handle it (no toast)
+    if (status === 400 || (status === 401 && isAuthEndpoint)) {
+      return Promise.reject(error);
+    }
+
+    // Everything else → toast (403, 404, 409, 500, network, timeout)
+    toast.error(getErrorMessage(error));
+    return Promise.reject(error);
+  }
 );
 
 export default apiClient;

--- a/src/lib/api-utils.ts
+++ b/src/lib/api-utils.ts
@@ -1,0 +1,95 @@
+import type { AxiosResponse } from 'axios';
+import { isAxiosError } from 'axios';
+import type { ApiResponse } from '@/types/api.types';
+import { ERROR_MESSAGES } from './constants';
+
+/**
+ * Unwraps a successful ApiResponse<T> → T.
+ * Throws if the response indicates failure.
+ */
+export function extractData<T>(response: AxiosResponse<ApiResponse<T>>): T {
+  const body = response.data;
+
+  if (!body.success || body.data == null) {
+    throw new Error(body.message || ERROR_MESSAGES.REQUEST_FAILED);
+  }
+
+  return body.data;
+}
+
+/**
+ * Extracts a single user-friendly error message from any error.
+ * Handles: network errors, timeouts, ErrorResponse, ValidationProblemDetails.
+ */
+export function getErrorMessage(error: unknown): string {
+  if (!isAxiosError(error)) {
+    return ERROR_MESSAGES.DEFAULT;
+  }
+
+  // No response — network or timeout
+  if (!error.response) {
+    return error.code === 'ECONNABORTED' ? ERROR_MESSAGES.TIMEOUT : ERROR_MESSAGES.NETWORK;
+  }
+
+  const body = error.response.data as Record<string, unknown> | undefined;
+  if (!body) return ERROR_MESSAGES.DEFAULT;
+
+  // ErrorResponse format: { message, errors: string[] }
+  if (Array.isArray(body.errors) && body.errors.length > 0) {
+    return body.errors[0] as string;
+  }
+
+  // ValidationProblemDetails: { title, errors: { Field: string[] } }
+  if (body.errors && !Array.isArray(body.errors)) {
+    const fieldErrors = Object.values(body.errors as Record<string, string[]>);
+    if (fieldErrors.length > 0 && fieldErrors[0].length > 0) {
+      return fieldErrors[0][0];
+    }
+  }
+
+  // ErrorResponse.message or ApiResponse.message
+  if (typeof body.message === 'string' && body.message) {
+    return body.message;
+  }
+
+  // ValidationProblemDetails.title
+  if (typeof body.title === 'string' && body.title) {
+    return body.title;
+  }
+
+  return ERROR_MESSAGES.DEFAULT;
+}
+
+/**
+ * Extracts all field-level validation errors for form display.
+ * Returns a map of { fieldName: "first error" } for React Hook Form's setError().
+ * Works with both ErrorResponse (flat) and ValidationProblemDetails (keyed).
+ */
+export function getFieldErrors(error: unknown): Record<string, string> | null {
+  if (!isAxiosError(error) || !error.response) return null;
+
+  const body = error.response.data as Record<string, unknown> | undefined;
+  if (!body?.errors) return null;
+
+  // ValidationProblemDetails: { errors: { Email: ["..."], Password: ["..."] } }
+  if (!Array.isArray(body.errors)) {
+    const fieldErrors: Record<string, string> = {};
+    for (const [field, messages] of Object.entries(body.errors as Record<string, string[]>)) {
+      if (messages.length > 0) {
+        // Convert PascalCase field name to camelCase (Email → email)
+        const key = field.charAt(0).toLowerCase() + field.slice(1);
+        fieldErrors[key] = messages[0];
+      }
+    }
+    return Object.keys(fieldErrors).length > 0 ? fieldErrors : null;
+  }
+
+  return null;
+}
+
+/**
+ * Returns true if the error is a validation error (400).
+ */
+export function isValidationError(error: unknown): boolean {
+  return isAxiosError(error) && error.response?.status === 400;
+}

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -1,5 +1,12 @@
 export const PLATFORM_ROLES = {
-    ADMIN: 'Admin',
-    MODERATOR: 'Moderator',
-    LEARNER: 'Learner'
+  ADMIN: 'Admin',
+  MODERATOR: 'Moderator',
+  LEARNER: 'Learner',
+} as const;
+
+export const ERROR_MESSAGES = {
+  TIMEOUT: 'Request timed out',
+  NETWORK: 'Unable to connect to server',
+  DEFAULT: 'Something went wrong',
+  REQUEST_FAILED: 'Request failed',
 } as const;

--- a/src/types/api.types.ts
+++ b/src/types/api.types.ts
@@ -7,6 +7,22 @@ export interface ApiResponse<T> {
   timestamp: string;
 }
 
+export interface ErrorResponse {
+  status: number;
+  message: string;
+  errors: string[];
+  details?: string;
+  timestamp: string;
+}
+
+export interface ValidationProblemDetails {
+  type: string;
+  title: string;
+  status: number;
+  errors: Record<string, string[]>;
+  traceId?: string;
+}
+
 export interface PaginatedResult<T> {
   items: T[];
   page: number;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,6 +1,6 @@
-import { defineConfig } from 'vite'
-import react from '@vitejs/plugin-react'
-import tailwindcss from '@tailwindcss/vite'
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+import tailwindcss from '@tailwindcss/vite';
 import path from 'path';
 
 // https://vite.dev/config/
@@ -12,4 +12,7 @@ export default defineConfig({
       '@': path.resolve(__dirname, './src'),
     },
   },
-})
+  server: {
+    sourcemapIgnoreList: (sourcePath) => sourcePath.includes('node_modules'),
+  },
+});


### PR DESCRIPTION
## Description

Improve the Axios client with proper error handling, toast notifications, and consistent error extraction from the backend's 3 response formats.

## Type of Change

- [x] New feature

## Changes Made

- **`src/lib/api-utils.ts`** — New file with 4 helpers:
  - `extractData<T>()` — unwraps `ApiResponse<T>` → `T`
  - `getErrorMessage()` — extracts user-friendly error string from any error
  - `getFieldErrors()` — extracts field-level validation errors for React Hook Form
  - `isValidationError()` — checks if error is a 400
- **`src/api/client.ts`** — Redesigned response interceptor:
  - 400 → no toast (forms handle inline)
  - 401 on `/auth/*` → no toast (forms handle)
  - 401 elsewhere → clear token, redirect to `/login`
  - Everything else (403, 404, 409, 500, network, timeout) → toast
- **`src/types/api.types.ts`** — Added `ErrorResponse` and `ValidationProblemDetails` interfaces
- **`src/lib/constants.ts`** — Added `ERROR_MESSAGES` constants
- **`eslint.config.js`** — Fixed rule name and allowed shadcn variant exports
- **`vite.config.ts`** — Added `sourcemapIgnoreList` for node_modules

## Related Issue

Closes #4

## How to Test

1. `npm run dev:staging`
2. Open browser console
3. Trigger API calls to verify:
   - 400 → no toast, error in console
   - 404 → toast appears
   - Network error (stop staging) → "Unable to connect to server" toast
4. `npm run build` → passes
5. `npm run lint` → passes

## Checklist

- [x] `npm run build` passes with no errors
- [x] `npm run lint` passes
- [x] Self-reviewed the code
- [x] No `any` types introduced
- [x] No `console.log` left in code
- [x] No hardcoded API URLs (use env vars)