### PR TITLE
feat: add auth context, provider, hooks and routing

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,6 +2,8 @@ import { BrowserRouter } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import { Toaster } from '@/components/ui/sonner';
+import { AuthProvider } from './context/AuthProvider';
+import AppRoutes from './routes';
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -17,12 +19,9 @@ function App() {
   return (
     <QueryClientProvider client={queryClient}>
       <BrowserRouter>
-        <div className="flex min-h-screen items-center justify-center">
-          <div className="text-center">
-            <h1 className="text-3xl font-bold">Letopia</h1>
-            <p className="mt-2 text-muted-foreground">Setup complete</p>
-          </div>
-        </div>
+        <AuthProvider>
+          <AppRoutes />
+        </AuthProvider>
       </BrowserRouter>
       <Toaster />
       <ReactQueryDevtools initialIsOpen={false} />

--- a/src/api/auth.api.ts
+++ b/src/api/auth.api.ts
@@ -1,0 +1,14 @@
+import apiClient from './client';
+import { extractData } from '@/lib/api-utils';
+import type { ApiResponse } from '@/types/api.types';
+import type { LoginRequest, SignUpRequest, AuthResponse } from '@/types/auth.types';
+
+export async function login(credentials: LoginRequest): Promise<AuthResponse> {
+  const response = await apiClient.post<ApiResponse<AuthResponse>>('/auth/login', credentials);
+  return extractData(response);
+}
+
+export async function signUp(credentials: SignUpRequest): Promise<AuthResponse> {
+  const response = await apiClient.post<ApiResponse<AuthResponse>>('/auth/signup', credentials);
+  return extractData(response);
+}

--- a/src/components/shared/ProtectedRoute.tsx
+++ b/src/components/shared/ProtectedRoute.tsx
@@ -1,0 +1,24 @@
+import { Navigate } from 'react-router-dom';
+import { useAuthContext } from '@/context/useAuthContext';
+import type { ReactNode } from 'react';
+
+interface ProtectedRouteProps {
+  children: ReactNode;
+}
+
+export function ProtectedRoute({ children }: ProtectedRouteProps) {
+  const { isAuthenticated, isLoading } = useAuthContext();
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center h-screen">
+        <p className="text-gray-500 text-lg">Loading...</p>
+      </div>
+    );
+  }
+  if (!isAuthenticated) {
+    return <Navigate to="/login" replace />;
+  }
+
+  return <>{children}</>;
+}

--- a/src/context/AuthContext.ts
+++ b/src/context/AuthContext.ts
@@ -1,0 +1,12 @@
+import { createContext } from 'react';
+import type { AuthUser, AuthResponse } from '@/types/auth.types';
+
+export interface AuthContextType {
+  user: AuthUser | null;
+  isAuthenticated: boolean;
+  isLoading: boolean;
+  login: (response: AuthResponse) => void;
+  logout: () => void;
+}
+
+export const AuthContext = createContext<AuthContextType | null>(null);

--- a/src/context/AuthProvider.tsx
+++ b/src/context/AuthProvider.tsx
@@ -1,0 +1,48 @@
+import { useEffect, useState, useCallback, type ReactNode } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { AuthContext } from './AuthContext';
+import type { AuthUser, AuthResponse } from '@/types/auth.types';
+
+interface AuthProviderProps {
+  children: ReactNode;
+}
+
+export function AuthProvider({ children }: AuthProviderProps) {
+  const [user, setUser] = useState<AuthUser | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    try {
+      const token = localStorage.getItem('authToken');
+      const storedUser = localStorage.getItem('user');
+      if (token && storedUser) {
+        setUser(JSON.parse(storedUser) as AuthUser);
+      }
+    } catch {
+      localStorage.removeItem('authToken');
+      localStorage.removeItem('user');
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  const login = useCallback((response: AuthResponse) => {
+    localStorage.setItem('authToken', response.jwtToken.token);
+    localStorage.setItem('user', JSON.stringify(response.user));
+    setUser(response.user);
+  }, []);
+
+  const logout = useCallback(() => {
+    localStorage.removeItem('authToken');
+    localStorage.removeItem('user');
+    setUser(null);
+    navigate('/login');
+  }, [navigate]);
+
+  return (
+    <AuthContext.Provider value={{ user, isAuthenticated: !!user, isLoading, login, logout }}>
+      {children}
+    </AuthContext.Provider>
+  );
+}

--- a/src/context/useAuthContext.ts
+++ b/src/context/useAuthContext.ts
@@ -1,0 +1,8 @@
+import { useContext } from 'react';
+import { AuthContext } from '@/context/AuthContext';
+
+export function useAuthContext() {
+  const ctx = useContext(AuthContext);
+  if (!ctx) throw new Error('useAuthContext must be used within an AuthProvider');
+  return ctx;
+}

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -1,0 +1,31 @@
+import { useMutation } from '@tanstack/react-query';
+import { useNavigate } from 'react-router-dom';
+import { login, signUp } from '@/api/auth.api';
+import { useAuthContext } from '@/context/useAuthContext';
+import type { LoginRequest, SignUpRequest } from '@/types/auth.types';
+
+export function useLogin() {
+  const { login: storeAuth } = useAuthContext();
+  const navigate = useNavigate();
+
+  return useMutation({
+    mutationFn: (data: LoginRequest) => login(data),
+    onSuccess: (response) => {
+      storeAuth(response);
+      navigate('/');
+    },
+  });
+}
+
+export function useSignup() {
+  const { login: storeAuth } = useAuthContext();
+  const navigate = useNavigate();
+
+  return useMutation({
+    mutationFn: (data: SignUpRequest) => signUp(data),
+    onSuccess: (response) => {
+      storeAuth(response);
+      navigate('/');
+    },
+  });
+}

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -1,7 +1,5 @@
 import { Routes, Route } from 'react-router-dom';
 import { ProtectedRoute } from './components/shared/ProtectedRoute';
-import LoginPage from './pages/auth/LoginPage';
-import SignUpPage from './pages/auth/SignUpPage';
 
 function HomePage() {
   return (
@@ -18,6 +16,15 @@ function NotFoundPage() {
       <p>Page not found</p>
     </div>
   );
+}
+
+// Placeholder until PR 2 (feature/auth-pages) is merged
+function LoginPage() {
+  return <div>Login Page - Coming in PR 2</div>;
+}
+
+function SignUpPage() {
+  return <div>SignUp Page - Coming in PR 2</div>;
 }
 
 export default function AppRoutes() {

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -1,0 +1,41 @@
+import { Routes, Route } from 'react-router-dom';
+import { ProtectedRoute } from './components/shared/ProtectedRoute';
+import LoginPage from './pages/auth/LoginPage';
+import SignUpPage from './pages/auth/SignUpPage';
+
+function HomePage() {
+  return (
+    <div className="p-8 text-2xl font-bold flex items-center justify-center">
+      Welcome to Letopia
+    </div>
+  );
+}
+
+function NotFoundPage() {
+  return (
+    <div className="h-screen text-2xl flex flex-col items-center justify-center">
+      <span className="text-4xl font-bold">404</span>
+      <p>Page not found</p>
+    </div>
+  );
+}
+
+export default function AppRoutes() {
+  return (
+    <Routes>
+      <Route path="/login" element={<LoginPage />} />
+      <Route path="/signup" element={<SignUpPage />} />
+
+      <Route
+        path="/"
+        element={
+          <ProtectedRoute>
+            <HomePage />
+          </ProtectedRoute>
+        }
+      />
+
+      <Route path="*" element={<NotFoundPage />} />
+    </Routes>
+  );
+}

--- a/src/types/auth.types.ts
+++ b/src/types/auth.types.ts
@@ -1,0 +1,33 @@
+import { PLATFORM_ROLES } from '@/lib/constants';
+
+export type PlatformRole = (typeof PLATFORM_ROLES)[keyof typeof PLATFORM_ROLES];
+
+export interface LoginRequest {
+  email: string;
+  password: string;
+}
+
+export interface SignUpRequest {
+  fullName: string;
+  email: string;
+  phoneNumber: string;
+  password: string;
+  confirmPassword: string;
+}
+
+export interface AuthUser {
+  id: string;
+  fullName: string;
+  email: string;
+  role: PlatformRole;
+}
+
+export interface TokenResult {
+  token: string;
+  expiresAt: string;
+}
+
+export interface AuthResponse {
+  jwtToken: TokenResult;
+  user: AuthUser;
+}


### PR DESCRIPTION
## Description

Auth infrastructure — the foundation for the full authentication system.
Covers types, API layer, context, hooks, and routing.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Styling / UI
- [ ] Documentation
- [ ] Configuration / CI

## Changes Made

- `src/types/auth.types.ts` — LoginRequest, SignUpRequest, AuthResponse, AuthUser types
- `src/api/auth.api.ts` — login() and signUp() API functions
- `src/context/AuthContext.tsx` — AuthProvider, useAuthContext hook, token persistence
- `src/hooks/useAuth.ts` — TanStack Query mutations for login + signup
- `src/components/shared/ProtectedRoute.tsx` — redirects unauthenticated users to /login
- `src/routes.tsx` — centralized route definitions
- `src/App.tsx` — wired AuthProvider + routes

## Related Issue

Part of #1

## Screenshots (if UI change)

N/A — infrastructure only, no UI changes in this PR.

## How to Test

1. `npm run dev`
2. Try accessing `/` without being logged in — should redirect to `/login`
3. Check localStorage after login — token should be stored
4. Refresh the page — user should still be authenticated
5. Logout — token should be cleared and redirected to `/login`

## Checklist

- [x] `npm run build` passes with no errors
- [x] `npm run lint` passes
- [x] Self-reviewed the code
- [x] No `any` types introduced
- [x] No `console.log` left in code
- [x] No hardcoded API URLs (use env vars)
