### PR TITLE
feat: add communities and categories API layer, types, and hooks

### DIFF
--- a/src/api/categories.api.ts
+++ b/src/api/categories.api.ts
@@ -1,0 +1,47 @@
+import apiClient from './client';
+import { extractData } from '@/lib/api-utils';
+import type { ApiResponse } from '@/types/api.types';
+import type { CategoryDto } from '@/types/category.types';
+
+// Get/categories?type=community
+
+export async function getCategories(type?: string): Promise<CategoryDto[]> {
+  const response = await apiClient.get<ApiResponse<CategoryDto[]>>('/categories', {
+    params: type ? { type } : undefined,
+  });
+  return extractData(response);
+}
+
+// Get/categories/{slug}
+export async function getCategoryBySlug(slug: string, type?: string): Promise<CategoryDto> {
+  const response = await apiClient.get<ApiResponse<CategoryDto>>(`/categories/${slug}`, {
+    params: type ? { type } : undefined,
+  });
+  return extractData(response);
+}
+
+// Post/categories
+export async function createCategory(categoryData: {
+  name: string;
+  iconUrl?: string;
+}): Promise<CategoryDto> {
+  const response = await apiClient.post<ApiResponse<CategoryDto>>('/categories', categoryData);
+  return extractData(response);
+}
+
+// Put/categories/{id}
+export async function updateCategory(
+  id: string,
+  categoryData: {
+    name?: string;
+    iconUrl?: string;
+  }
+): Promise<CategoryDto> {
+  const response = await apiClient.put<ApiResponse<CategoryDto>>(`/categories/${id}`, categoryData);
+  return extractData(response);
+}
+
+// Delete/categories/{id}
+export async function deleteCategory(id: string): Promise<void> {
+  await apiClient.delete(`/categories/${id}`);
+}

--- a/src/api/communities.api.ts
+++ b/src/api/communities.api.ts
@@ -1,0 +1,133 @@
+import apiClient from './client';
+import { extractData } from '@/lib/api-utils';
+import type { ApiResponse, PaginatedResult } from '@/types/api.types';
+import type {
+  CommunitySummary,
+  CommunityDetail,
+  CommunityMember,
+  CommunityMemberRole,
+  CreateCommunityRequest,
+  UpdateCommunityRequest,
+  ListCommunitiesQuery,
+} from '@/types/community.types';
+
+/**
+ * GET /communities
+ */
+export async function getCommunities(
+  params?: ListCommunitiesQuery
+): Promise<PaginatedResult<CommunitySummary>> {
+  const response = await apiClient.get<ApiResponse<PaginatedResult<CommunitySummary>>>(
+    '/communities',
+    { params }
+  );
+  return extractData(response);
+}
+
+/**
+ * GET /communities/me
+ */
+export async function getMyCommunities(): Promise<PaginatedResult<CommunitySummary>> {
+  const response =
+    await apiClient.get<ApiResponse<PaginatedResult<CommunitySummary>>>('/communities/me');
+  return extractData(response);
+}
+
+/**
+ * GET /communities/{slug}
+ */
+export async function getCommunityBySlug(slug: string): Promise<CommunityDetail> {
+  const response = await apiClient.get<ApiResponse<CommunityDetail>>(`/communities/${slug}`);
+  return extractData(response);
+}
+
+/**
+ * POST /communities  (multipart/form-data)
+ */
+export async function createCommunity(data: CreateCommunityRequest): Promise<CommunityDetail> {
+  const formData = new FormData();
+  formData.append('name', data.name);
+  formData.append('description', data.description);
+  if (data.privacy !== undefined) {
+    formData.append('isPrivate', String(data.privacy === 'Private'));
+  }
+  formData.append('categoryId', data.categoryId);
+  data.rules?.forEach((rule) => formData.append(`rules`, rule));
+  if (data.coverImage) {
+    formData.append('coverImage', data.coverImage);
+  }
+  const response = await apiClient.post<ApiResponse<CommunityDetail>>('/communities', formData, {
+    headers: {
+      'Content-Type': 'multipart/form-data',
+    },
+  });
+  return extractData(response);
+}
+
+/**
+ * PUT /communities/{id}  (multipart/form-data)
+ */
+export async function updateCommunity(
+  id: string,
+  data: UpdateCommunityRequest
+): Promise<CommunityDetail> {
+  const formData = new FormData();
+  if (data.name) formData.append('name', data.name);
+  if (data.description) formData.append('description', data.description);
+  if (data.privacy !== undefined) formData.append('isPrivate', String(data.privacy === 'Private'));
+  if (data.rules) data.rules.forEach((rule) => formData.append(`rules`, rule));
+  if (data.coverImage) {
+    formData.append('coverImage', data.coverImage);
+  }
+  const response = await apiClient.put<ApiResponse<CommunityDetail>>(
+    `/communities/${id}`,
+    formData,
+    {
+      headers: {
+        'Content-Type': 'multipart/form-data',
+      },
+    }
+  );
+  return extractData(response);
+}
+
+/**
+ * POST /communities/{id}/join
+ */
+export async function joinCommunity(id: string): Promise<void> {
+  await apiClient.post(`/communities/${id}/join`);
+}
+
+/**
+ * DELETE /communities/{id}/leave
+ */
+export async function leaveCommunity(id: string): Promise<void> {
+  await apiClient.delete(`/communities/${id}/leave`);
+}
+
+/**
+ * GET /communities/{id}/members
+ */
+export async function getCommunityMembers(
+  id: string,
+  params?: { page?: number; pageSize?: number }
+): Promise<PaginatedResult<CommunityMember>> {
+  const response = await apiClient.get<ApiResponse<PaginatedResult<CommunityMember>>>(
+    `/communities/${id}/members`,
+    { params }
+  );
+  return extractData(response);
+}
+
+/**
+ * PUT /communities/{id}/members/{userId}/role
+ */
+export async function changeMemberRole(
+  communityId: string,
+  memberId: string,
+  newRole: CommunityMemberRole
+): Promise<void> {
+  await apiClient.put(`/communities/${communityId}/members/${memberId}/role`, {
+    role: newRole,
+  });
+}

--- a/src/hooks/useCategories.ts
+++ b/src/hooks/useCategories.ts
@@ -1,0 +1,62 @@
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import {
+  getCategories,
+  getCategoryBySlug,
+  createCategory,
+  updateCategory,
+  deleteCategory,
+} from '@/api/categories.api';
+
+export const categoryQueryKey = {
+  all: ['categories'] as const,
+  list: (type?: string) => ['categories', 'list', { type }] as const,
+  detail: (slug: string) => ['categories', 'detail', slug] as const,
+};
+
+export function useCategoriesList(type?: string) {
+  return useQuery({
+    queryKey: categoryQueryKey.list(type),
+    queryFn: () => getCategories(type),
+    staleTime: 1000 * 60 * 10, // 10 minutes
+  });
+}
+
+export function useCategoryBySlug(slug: string, type?: string) {
+  return useQuery({
+    queryKey: categoryQueryKey.detail(slug),
+    queryFn: () => getCategoryBySlug(slug, type),
+    enabled: !!slug,
+    staleTime: 1000 * 60 * 10, // 10 minutes
+  });
+}
+
+export function useCreateCategory() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: createCategory,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: categoryQueryKey.all });
+    },
+  });
+}
+
+export function useUpdateCategory() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({ id, data }: { id: string; data: { name?: string; iconUrl?: string } }) =>
+      updateCategory(id, data),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: categoryQueryKey.all });
+    },
+  });
+}
+
+export function useDeleteCategory() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: deleteCategory,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: categoryQueryKey.all });
+    },
+  });
+}

--- a/src/hooks/useCommunities.ts
+++ b/src/hooks/useCommunities.ts
@@ -1,0 +1,128 @@
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import {
+  getCommunities,
+  getMyCommunities,
+  createCommunity,
+  joinCommunity,
+  updateCommunity,
+  leaveCommunity,
+  getCommunityMembers,
+  changeMemberRole,
+  getCommunityBySlug,
+} from '@/api/communities.api';
+import type {
+  ListCommunitiesQuery,
+  UpdateCommunityRequest,
+  CommunityMemberRole,
+} from '@/types/community.types';
+
+export const communitiesQueryKey = {
+  all: ['communities'] as const,
+  mine: () => ['communities', 'mine'] as const,
+  list: (params?: ListCommunitiesQuery) => ['communities', 'list', params] as const,
+  detail: (slug: string) => ['communities', 'detail', slug] as const,
+  members: (id: string) => ['communities', 'members', id] as const,
+};
+
+// GET /communities
+export function useCommunities(params?: ListCommunitiesQuery) {
+  return useQuery({
+    queryKey: communitiesQueryKey.list(params),
+    queryFn: () => getCommunities(params),
+  });
+}
+
+// GET /communities/me
+export function useMyCommunities() {
+  return useQuery({
+    queryKey: communitiesQueryKey.mine(),
+    queryFn: getMyCommunities,
+  });
+}
+
+// GET /communities/{slug}
+export function useCommunityDetail(slug: string) {
+  return useQuery({
+    queryKey: communitiesQueryKey.detail(slug),
+    queryFn: () => getCommunityBySlug(slug),
+    enabled: !!slug,
+  });
+}
+
+// GET /communities/{id}/members
+export function useCommunityMembers(id: string) {
+  return useQuery({
+    queryKey: communitiesQueryKey.members(id),
+    queryFn: () => getCommunityMembers(id),
+    enabled: !!id,
+  });
+}
+
+// POST /communities
+export function useCreateCommunity() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: createCommunity,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: communitiesQueryKey.all });
+      queryClient.invalidateQueries({ queryKey: communitiesQueryKey.mine() });
+    },
+  });
+}
+
+// POST /communities/{id}/join
+export function useJoinCommunity() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: joinCommunity,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: communitiesQueryKey.all });
+      queryClient.invalidateQueries({ queryKey: communitiesQueryKey.mine() });
+    },
+  });
+}
+
+// PUT /communities/{id}
+export function useUpdateCommunity() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({ id, data }: { id: string; data: UpdateCommunityRequest }) =>
+      updateCommunity(id, data),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: communitiesQueryKey.all });
+    },
+  });
+}
+
+// DELETE /communities/{id}/leave
+export function useLeaveCommunity() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: leaveCommunity,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: communitiesQueryKey.all });
+      queryClient.invalidateQueries({ queryKey: communitiesQueryKey.mine() });
+    },
+  });
+}
+
+// PUT /communities/{id}/members/{userId}/role
+export function useChangeMemberRole() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({
+      communityId,
+      userId,
+      newRole,
+    }: {
+      communityId: string;
+      userId: string;
+      newRole: CommunityMemberRole;
+    }) => changeMemberRole(communityId, userId, newRole),
+    onSuccess: (_data, variables) => {
+      queryClient.invalidateQueries({
+        queryKey: communitiesQueryKey.members(variables.communityId),
+      });
+    },
+  });
+}

--- a/src/types/category.types.ts
+++ b/src/types/category.types.ts
@@ -1,0 +1,6 @@
+export interface CategoryDto {
+  id: string;
+  name: string;
+  slug: string;
+  iconUrl?: string;
+}

--- a/src/types/community.types.ts
+++ b/src/types/community.types.ts
@@ -1,0 +1,61 @@
+import type { PaginatedQuery } from './api.types';
+
+export type CommunityPrivacy = 'Public' | 'Private';
+export type CommunityMemberRole = 'Member' | 'Moderator' | 'Admin';
+export type JoinStatus = 'none' | 'pending' | 'joined';
+
+export interface CommunityCategory {
+  id: string;
+  name: string;
+  slug: string;
+}
+
+export interface CommunitySummary {
+  id: string;
+  name: string;
+  slug: string;
+  description: string;
+  coverImageUrl?: string;
+  privacy: CommunityPrivacy;
+  memberCount: number;
+  onlineMemberCount?: number;
+  category: CommunityCategory;
+  joinStatus: JoinStatus;
+}
+
+export interface CommunityDetail extends CommunitySummary {
+  rules: string[];
+}
+
+export interface CommunityMember {
+  id: string;
+  fullName: string;
+  email: string;
+  avatarUrl?: string;
+  bio?: string;
+  role: CommunityMemberRole;
+  joinedAt: string;
+}
+
+export interface CreateCommunityRequest {
+  name: string;
+  description: string;
+  coverImage?: File;
+  privacy?: CommunityPrivacy;
+  categoryId: string;
+  rules?: string[];
+}
+
+export interface UpdateCommunityRequest {
+  name?: string;
+  description?: string;
+  coverImage?: File;
+  privacy?: CommunityPrivacy;
+  rules?: string[];
+}
+
+export interface ListCommunitiesQuery extends PaginatedQuery {
+  search?: string;
+  categorySlug?: string;
+  privacy?: CommunityPrivacy;
+}


### PR DESCRIPTION
## Description
Add the full API layer for communities and categories features.
## Type of Change

- [ ] Bug fix
- [X] New feature
- [ ] Refactor
- [ ] Styling / UI
- [ ] Documentation
- [ ] Configuration / CI

## Changes Made


- Added `categories.api.ts` : getCategories, getCategoryBySlug, createCategory, updateCategory, deleteCategory

- Added `communities.api.ts` : getCommunities, getMyCommunities, getCommunityBySlug, createCommunity, updateCommunity, joinCommunity, leaveCommunity, getCommunityMembers, changeMemberRole

- Added `category.types.ts` and `community.types.ts` mirroring backend DTOs

- Added `useCategories.ts` and `useCommunities.ts` TanStack Query hooks


## Related Issue

#11 

## Screenshots (if UI change)

N/A

## How to Test

1. `npm run dev`
2. `npm run type-check`

## Checklist

- [X] `npm run build` passes with no errors
- [X] `npm run lint` passes
- [X] Self-reviewed the code
- [X] No `any` types introduced
- [X] No `console.log` left in code
- [X] No hardcoded API URLs (use env vars)
