### PR TITLE
feat: setup design system with Lexend Deca font and brand color palette

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,6 +3,9 @@
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Lexend+Deca:wght@400;600;700&display=swap" rel="stylesheet" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>letopia-webapp</title>
   </head>

--- a/src/index.css
+++ b/src/index.css
@@ -1,17 +1,15 @@
-@import "tailwindcss";
-@import "tw-animate-css";
-@import "shadcn/tailwind.css";
+@import 'tailwindcss';
+@import 'tw-animate-css';
+@import 'shadcn/tailwind.css';
 
 @custom-variant dark (&:is(.dark *));
 
 :root {
-  font-family: system-ui, Avenir, Helvetica, Arial, sans-serif;
+  font-family: 'Lexend Deca', sans-serif;
   line-height: 1.5;
   font-weight: 400;
 
   color-scheme: light dark;
-  color: rgba(255, 255, 255, 0.87);
-  background-color: #242424;
 
   font-synthesis: none;
   text-rendering: optimizeLegibility;
@@ -24,18 +22,18 @@
   --card-foreground: oklch(0.145 0 0);
   --popover: oklch(1 0 0);
   --popover-foreground: oklch(0.145 0 0);
-  --primary: oklch(0.205 0 0);
-  --primary-foreground: oklch(0.985 0 0);
+  --primary: #6a0dad;
+  --primary-foreground: #f0e7f7;
   --secondary: oklch(0.97 0 0);
   --secondary-foreground: oklch(0.205 0 0);
   --muted: oklch(0.97 0 0);
   --muted-foreground: oklch(0.556 0 0);
-  --accent: oklch(0.97 0 0);
-  --accent-foreground: oklch(0.205 0 0);
+  --accent: #f0e7f7;
+  --accent-foreground: #4b097b;
   --destructive: oklch(0.577 0.245 27.325);
   --border: oklch(0.922 0 0);
   --input: oklch(0.922 0 0);
-  --ring: oklch(0.708 0 0);
+  --ring: #883dbd;
   --chart-1: oklch(0.646 0.222 41.116);
   --chart-2: oklch(0.6 0.118 184.704);
   --chart-3: oklch(0.398 0.07 227.392);
@@ -51,58 +49,10 @@
   --sidebar-ring: oklch(0.708 0 0);
 }
 
-a {
-  font-weight: 500;
-  color: #646cff;
-  text-decoration: inherit;
-}
-a:hover {
-  color: #535bf2;
-}
-
 body {
   margin: 0;
-  display: flex;
-  place-items: center;
   min-width: 320px;
   min-height: 100vh;
-}
-
-h1 {
-  font-size: 3.2em;
-  line-height: 1.1;
-}
-
-button {
-  border-radius: 8px;
-  border: 1px solid transparent;
-  padding: 0.6em 1.2em;
-  font-size: 1em;
-  font-weight: 500;
-  font-family: inherit;
-  background-color: #1a1a1a;
-  cursor: pointer;
-  transition: border-color 0.25s;
-}
-button:hover {
-  border-color: #646cff;
-}
-button:focus,
-button:focus-visible {
-  outline: 4px auto -webkit-focus-ring-color;
-}
-
-@media (prefers-color-scheme: light) {
-  :root {
-    color: #213547;
-    background-color: #ffffff;
-  }
-  a:hover {
-    color: #747bff;
-  }
-  button {
-    background-color: #f9f9f9;
-  }
 }
 
 @theme inline {
@@ -144,6 +94,49 @@ button:focus-visible {
   --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
   --color-sidebar-border: var(--sidebar-border);
   --color-sidebar-ring: var(--sidebar-ring);
+
+  /* Brand palette (vibrant purple) */
+  --color-brand-50: #f0e7f7;
+  --color-brand-100: #d7b4e6;
+  --color-brand-200: #ba90d9;
+  --color-brand-300: #9b5dc8;
+  --color-brand-400: #883dbd;
+  --color-brand-500: #6a0dad;
+  --color-brand-600: #600c9d;
+  --color-brand-700: #4b097b;
+  --color-brand-800: #3a075f;
+  --color-brand-900: #2d0549;
+
+  /* Purple palette */
+  --color-purple-50: #efedf1;
+  --color-purple-100: #cfc6d4;
+  --color-purple-200: #b7abc0;
+  --color-purple-300: #9684a3;
+  --color-purple-400: #826d91;
+  --color-purple-500: #634875;
+  --color-purple-600: #5a426a;
+  --color-purple-700: #463353;
+  --color-purple-800: #362840;
+  --color-purple-900: #2a1e31;
+
+  /* Violet palette */
+  --color-violet-50: #f1edf6;
+  --color-violet-100: #d5c7e2;
+  --color-violet-200: #c0acd4;
+  --color-violet-300: #a386c1;
+  --color-violet-400: #916fb5;
+  --color-violet-500: #764ba2;
+  --color-violet-600: #6b4493;
+  --color-violet-700: #543573;
+  --color-violet-800: #412959;
+  --color-violet-900: #322044;
+
+  --font-size-display: 44px;
+  --font-size-h1: 33px;
+  --font-size-h2: 24px;
+  --font-size-h3: 19px;
+  --font-size-body: 14px;
+  --font-size-caption: 11px;
 }
 
 .dark {
@@ -153,18 +146,18 @@ button:focus-visible {
   --card-foreground: oklch(0.985 0 0);
   --popover: oklch(0.205 0 0);
   --popover-foreground: oklch(0.985 0 0);
-  --primary: oklch(0.922 0 0);
-  --primary-foreground: oklch(0.205 0 0);
+  --primary: #ba90d9;
+  --primary-foreground: #2d0549;
   --secondary: oklch(0.269 0 0);
   --secondary-foreground: oklch(0.985 0 0);
   --muted: oklch(0.269 0 0);
   --muted-foreground: oklch(0.708 0 0);
-  --accent: oklch(0.269 0 0);
-  --accent-foreground: oklch(0.985 0 0);
+  --accent: #4b097b;
+  --accent-foreground: #f0e7f7;
   --destructive: oklch(0.704 0.191 22.216);
   --border: oklch(1 0 0 / 10%);
   --input: oklch(1 0 0 / 15%);
-  --ring: oklch(0.556 0 0);
+  --ring: #9b5dc8;
   --chart-1: oklch(0.488 0.243 264.376);
   --chart-2: oklch(0.696 0.17 162.48);
   --chart-3: oklch(0.769 0.188 70.08);


### PR DESCRIPTION
## Description

Sets up the Letopia platform design system by configuring the custom font, typography scale, and brand color palettes in the Tailwind CSS theme.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [x] Styling / UI
- [ ] Documentation
- [x] Configuration / CI

## Changes Made

- Added Lexend Deca Google Font (400, 600, 700 weights) in `index.html`
- Set Lexend Deca as default font-family in `:root`
- Added type scale tokens: `display` (44px), `h1` (33px), `h2` (24px), `h3` (19px), `body` (14px), `caption` (11px)
- Added three 50–900 color palettes (`brand-*`, `purple-*`, `violet-*`) to `@theme inline`
- Updated shadcn/ui semantic tokens (`--primary`, `--accent`, `--ring`) to use brand purple for both light and dark modes
- Removed Vite scaffold boilerplate styles (link colors, button styles, `h1` override, `place-items: center`, `prefers-color-scheme` media query)

## How to Test

1. `npm run dev`
2. Verify the font is Lexend Deca (check in browser DevTools)
3. Verify shadcn/ui `Button` renders with brand purple (`#6a0dad`)
4. Toggle dark mode — primary should switch to lighter purple (`#ba90d9`)
5. Use `bg-brand-500`, `text-violet-300`, `text-purple-400` in a test component to confirm palette works

## Checklist

- [x] `npm run build` passes with no errors
- [x] `npm run lint` passes
- [x] Self-reviewed the code
- [x] No `any` types introduced
- [x] No `console.log` left in code
- [x] No hardcoded API URLs (use env vars)