### PR TITLE
feat: add communities and categories types, api layer, and hooks

### DIFF
--- a/src/api/categories.api.ts
+++ b/src/api/categories.api.ts
@@ -1,0 +1,10 @@
+import apiClient from './client';
+import type { ApiResponse } from '@/types/api.types';
+import type { Category } from '@/types/category.types';
+
+export const categoriesApi = {
+  getByType: (type: string) =>
+    apiClient.get<ApiResponse<Category[]>>('/categories', {
+      params: { type },
+    }),
+};

--- a/src/api/communities.api.ts
+++ b/src/api/communities.api.ts
@@ -36,7 +36,9 @@ export const communitiesApi = {
     }
     data.rules?.forEach((rule) => formData.append('rules', rule));
 
-    return apiClient.post<ApiResponse<CommunityDetail>>('/communities', formData);
+    return apiClient.post('/communities', formData, {
+      headers: { 'Content-Type': undefined },
+    });
   },
 
   update: (id: string, data: UpdateCommunityRequest) => {
@@ -47,6 +49,8 @@ export const communitiesApi = {
     if (data.coverImage) formData.append('coverImage', data.coverImage);
     data.rules?.forEach((rule) => formData.append('rules', rule));
 
-    return apiClient.put<ApiResponse<CommunityDetail>>(`/communities/${id}`, formData);
+    return apiClient.put<ApiResponse<CommunityDetail>>(`/communities/${id}`, formData, {
+      headers: { 'Content-Type': undefined },
+    });
   },
 };

--- a/src/api/communities.api.ts
+++ b/src/api/communities.api.ts
@@ -1,0 +1,52 @@
+import apiClient from './client';
+import type { ApiResponse, PaginatedQuery, PaginatedResult } from '@/types/api.types';
+import type {
+  CommunitySummary,
+  CommunityDetail,
+  CreateCommunityRequest,
+  UpdateCommunityRequest,
+  JoinedCommunitySummary,
+  Member,
+  CommunityListParams,
+} from '@/types/community.types';
+
+export const communitiesApi = {
+  getBySlug: (slug: string) => apiClient.get<ApiResponse<CommunityDetail>>(`/communities/${slug}`),
+
+  getMyCommunities: () => apiClient.get<ApiResponse<JoinedCommunitySummary[]>>(`/communities/me`),
+
+  list: (params: CommunityListParams) =>
+    apiClient.get<ApiResponse<PaginatedResult<CommunitySummary>>>(`/communities`, { params }),
+
+  getMembers: (id: string, params: PaginatedQuery) =>
+    apiClient.get<ApiResponse<PaginatedResult<Member>>>(`/communities/${id}/members`, { params }),
+
+  join: (id: string) => apiClient.post(`/communities/${id}/join`),
+
+  leave: (id: string) => apiClient.delete(`/communities/${id}/leave`),
+
+  create: (data: CreateCommunityRequest) => {
+    const formData = new FormData();
+    formData.append('name', data.name);
+    formData.append('description', data.description);
+    formData.append('categoryId', data.categoryId);
+    formData.append('isPrivate', String(data.isPrivate ?? false));
+    if (data.coverImage) {
+      formData.append('coverImage', data.coverImage);
+    }
+    data.rules?.forEach((rule) => formData.append('rules', rule));
+
+    return apiClient.post<ApiResponse<CommunityDetail>>('/communities', formData);
+  },
+
+  update: (id: string, data: UpdateCommunityRequest) => {
+    const formData = new FormData();
+    if (data.name) formData.append('name', data.name);
+    if (data.description) formData.append('description', data.description);
+    if (data.isPrivate !== undefined) formData.append('isPrivate', String(data.isPrivate));
+    if (data.coverImage) formData.append('coverImage', data.coverImage);
+    data.rules?.forEach((rule) => formData.append('rules', rule));
+
+    return apiClient.put<ApiResponse<CommunityDetail>>(`/communities/${id}`, formData);
+  },
+};

--- a/src/api/communities.api.ts
+++ b/src/api/communities.api.ts
@@ -36,7 +36,7 @@ export const communitiesApi = {
     }
     data.rules?.forEach((rule) => formData.append('rules', rule));
 
-    return apiClient.post('/communities', formData, {
+    return apiClient.post<ApiResponse<CommunityDetail>>('/communities', formData, {
       headers: { 'Content-Type': undefined },
     });
   },

--- a/src/hooks/useCategories.ts
+++ b/src/hooks/useCategories.ts
@@ -5,5 +5,6 @@ export function useCategoriesList(type: string) {
   return useQuery({
     queryKey: ['categories', type],
     queryFn: () => categoriesApi.getByType(type).then((res) => res.data),
+    enabled: !!type,
   });
 }

--- a/src/hooks/useCategories.ts
+++ b/src/hooks/useCategories.ts
@@ -1,0 +1,9 @@
+import { useQuery } from '@tanstack/react-query';
+import { categoriesApi } from '@/api/categories.api';
+
+export function useCategoriesList(type: string) {
+  return useQuery({
+    queryKey: ['categories', type],
+    queryFn: () => categoriesApi.getByType(type).then((res) => res.data),
+  });
+}

--- a/src/hooks/useCommunities.ts
+++ b/src/hooks/useCommunities.ts
@@ -1,0 +1,105 @@
+import { communitiesApi } from '@/api/communities.api';
+import { useMutation, useQuery } from '@tanstack/react-query';
+import type {
+  CommunityListParams,
+  CreateCommunityRequest,
+  UpdateCommunityRequest,
+} from '@/types/community.types';
+import type { ApiResponse, PaginatedQuery } from '@/types/api.types';
+import type { AxiosError } from 'axios';
+import { toast } from 'sonner';
+import { useNavigate } from 'react-router-dom';
+
+export function useCommunitiesList(params: CommunityListParams) {
+  return useQuery({
+    queryKey: ['communities', params],
+    queryFn: () => communitiesApi.list(params).then((res) => res.data),
+  });
+}
+
+export function useCommunityBySlug(slug: string) {
+  return useQuery({
+    queryKey: ['communities', slug],
+    queryFn: () => communitiesApi.getBySlug(slug).then((res) => res.data),
+  });
+}
+
+export function useMyCommunities() {
+  return useQuery({
+    queryKey: ['communities', 'me'],
+    queryFn: () => communitiesApi.getMyCommunities().then((res) => res.data),
+  });
+}
+
+export function useCommunityMembers(id: string, params: PaginatedQuery) {
+  return useQuery({
+    queryKey: ['communities', id, 'members', params],
+    queryFn: () => communitiesApi.getMembers(id, params).then((res) => res.data),
+  });
+}
+
+export function useJoinCommunity() {
+  return useMutation({
+    mutationFn: (id: string) => communitiesApi.join(id),
+    onSuccess: () => {
+      toast.success('Joined community successfully!');
+    },
+    onError: (error: AxiosError<ApiResponse<null>>) => {
+      const message = error.response?.data?.message ?? 'Failed to join community';
+      toast.error(message);
+    },
+  });
+}
+
+export function useLeaveCommunity() {
+  const navigate = useNavigate();
+  return useMutation({
+    mutationFn: (id: string) => communitiesApi.leave(id),
+    onSuccess: () => {
+      toast.success('Left community successfully');
+      navigate('/communities');
+    },
+    onError: (error: AxiosError<ApiResponse<null>>) => {
+      const message = error.response?.data?.message ?? 'Failed to leave community';
+      toast.error(message);
+    },
+  });
+}
+
+export function useCreateCommunity() {
+  const navigate = useNavigate();
+
+  return useMutation({
+    mutationFn: (data: CreateCommunityRequest) =>
+      communitiesApi.create(data).then((res) => res.data),
+    onSuccess: (response) => {
+      if (response.data) {
+        toast.success('Community created successfully!');
+        navigate(`/communities/${response.data.slug}`);
+      }
+    },
+    onError: (error: AxiosError<ApiResponse<null>>) => {
+      const message = error.response?.data?.message ?? 'Failed to create community';
+      toast.error(message);
+    },
+  });
+}
+
+export function useUpdateCommunity() {
+  const navigate = useNavigate();
+
+  return useMutation({
+    mutationFn: ({ id, data }: { id: string; data: UpdateCommunityRequest }) =>
+      communitiesApi.update(id, data).then((res) => res.data),
+    onSuccess: (response) => {
+      if (response.data) {
+        toast.success('Community updated successfully!');
+        navigate(`/communities/${response.data.slug}`);
+      }
+    },
+    onError: (error: AxiosError<ApiResponse<null>>) => {
+      const message = error.response?.data?.message ?? 'Failed to update community';
+      toast.error(message);
+    },
+  });
+}

--- a/src/hooks/useCommunities.ts
+++ b/src/hooks/useCommunities.ts
@@ -1,5 +1,5 @@
 import { communitiesApi } from '@/api/communities.api';
-import { useMutation, useQuery } from '@tanstack/react-query';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import type {
   CommunityListParams,
   CreateCommunityRequest,
@@ -39,10 +39,12 @@ export function useCommunityMembers(id: string, params: PaginatedQuery) {
 }
 
 export function useJoinCommunity() {
+  const queryClient = useQueryClient();
   return useMutation({
     mutationFn: (id: string) => communitiesApi.join(id),
     onSuccess: () => {
       toast.success('Joined community successfully!');
+      queryClient.invalidateQueries({ queryKey: ['communities'] });
     },
     onError: (error: AxiosError<ApiResponse<null>>) => {
       const message = error.response?.data?.message ?? 'Failed to join community';
@@ -52,11 +54,14 @@ export function useJoinCommunity() {
 }
 
 export function useLeaveCommunity() {
+  const queryClient = useQueryClient();
   const navigate = useNavigate();
+
   return useMutation({
     mutationFn: (id: string) => communitiesApi.leave(id),
     onSuccess: () => {
       toast.success('Left community successfully');
+      queryClient.invalidateQueries({ queryKey: ['communities'] });
       navigate('/communities');
     },
     onError: (error: AxiosError<ApiResponse<null>>) => {
@@ -67,6 +72,7 @@ export function useLeaveCommunity() {
 }
 
 export function useCreateCommunity() {
+  const queryClient = useQueryClient();
   const navigate = useNavigate();
 
   return useMutation({
@@ -75,6 +81,7 @@ export function useCreateCommunity() {
     onSuccess: (response) => {
       if (response.data) {
         toast.success('Community created successfully!');
+        queryClient.invalidateQueries({ queryKey: ['communities'] });
         navigate(`/communities/${response.data.slug}`);
       }
     },
@@ -86,6 +93,7 @@ export function useCreateCommunity() {
 }
 
 export function useUpdateCommunity() {
+  const queryClient = useQueryClient();
   const navigate = useNavigate();
 
   return useMutation({
@@ -94,6 +102,7 @@ export function useUpdateCommunity() {
     onSuccess: (response) => {
       if (response.data) {
         toast.success('Community updated successfully!');
+        queryClient.invalidateQueries({ queryKey: ['communities'] });
         navigate(`/communities/${response.data.slug}`);
       }
     },

--- a/src/types/category.types.ts
+++ b/src/types/category.types.ts
@@ -1,0 +1,7 @@
+export interface Category {
+  id: string;
+  name: string;
+  slug: string;
+  iconUrl: string | null;
+  type: string;
+}

--- a/src/types/community.types.ts
+++ b/src/types/community.types.ts
@@ -1,0 +1,77 @@
+import type { PaginatedQuery } from './api.types';
+
+export type CommunityRole = 'Member' | 'Moderator' | 'Owner';
+
+export interface ChannelSummary {
+  id: string;
+  name: string;
+  slug: string;
+  channelType: string | null;
+  description: string | null;
+  postCount: number;
+  isDefault: boolean;
+  isArchived: boolean;
+  allowMemberPosts: boolean;
+  allowComments: boolean;
+  displayOrder: number;
+  subChannels: ChannelSummary[];
+}
+
+export interface CommunitySummary {
+  id: string;
+  name: string;
+  slug: string;
+  description: string;
+  categoryId: string;
+  categoryName: string;
+  iconUrl: string | null;
+  coverImageUrl: string | null;
+  memberCount: number;
+  postCount: number;
+  isPrivate: boolean;
+  createdAt: string;
+}
+
+export interface CommunityDetail extends CommunitySummary {
+  lastPostAt: string | null;
+  isMember: boolean;
+  userRole: CommunityRole | null;
+  rules: string[];
+  channels: ChannelSummary[];
+}
+
+export interface JoinedCommunitySummary {
+  community: CommunitySummary;
+  joinedAt: string;
+}
+
+export interface Member {
+  userId: string;
+  fullName: string;
+  avatarUrl: string | null;
+  role: CommunityRole;
+  joinedAt: string;
+}
+
+export interface CreateCommunityRequest {
+  name: string;
+  description: string;
+  categoryId: string;
+  isPrivate?: boolean;
+  coverImage?: File;
+  rules?: string[];
+}
+
+export interface UpdateCommunityRequest {
+  name?: string;
+  description?: string;
+  isPrivate?: boolean;
+  coverImage?: File;
+  rules?: string[];
+}
+
+export interface CommunityListParams extends PaginatedQuery {
+  category?: string;
+  search?: string;
+  sortBy?: string;
+}


### PR DESCRIPTION
## Description
Add the foundational layer for the Communities feature:
types, API module, and TanStack Query hooks for both
communities and categories.

## Type of Change

- [ ] Bug fix
- [X] New feature
- [ ] Refactor
- [ ] Styling / UI
- [ ] Documentation
- [ ] Configuration / CI

## Changes Made
- Added `community.types.ts` — Communities interfaces
- Added `category.types.ts` — Category interface
- Added `communities.api.ts` — all community endpoints (list, create, update, join, leave, members)
- Added `categories.api.ts` — getByType endpoint
- Added `useCommunities.ts` — TanStack Query hooks for all community operations
- Added `useCategories.ts` — useCategoriesList hook

## Related Issue
#11

## Screenshots (if UI change)

N/A
## How to Test

1. `npm run dev`
2. No visual testing needed — logic layer only

## Checklist

- [X] `npm run build` passes with no errors
- [X] `npm run lint` passes
- [X] Self-reviewed the code
- [X] No `any` types introduced
- [X] No `console.log` left in code
- [X] No hardcoded API URLs (use env vars)
