### PR TITLE
feat(auth): implement forgot-password flow (request → verify code → set new password)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,6 +9,9 @@ import { LoginPage } from '@/pages/auth/LoginPage';
 import { RegisterPage } from '@/pages/auth/RegisterPage';
 import { HomePage } from '@/pages/HomePage';
 import { VerifyEmailPage } from '@/pages/auth/VerifyEmailPage';
+import { ForgotPasswordPage } from '@/pages/auth/ForgotPasswordPage';
+import { VerifyResetCodePage } from '@/pages/auth/VerifyResetCodePage';
+import { SetPasswordPage } from '@/pages/auth/SetPasswordPage';
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -35,6 +38,9 @@ function App() {
                 <Route path="login" element={<LoginPage />} />
                 <Route path="register" element={<RegisterPage />} />
                 <Route path="verify-email" element={<VerifyEmailPage />} />
+                <Route path="forgot-password" element={<ForgotPasswordPage />} />
+                <Route path="verify-reset-code" element={<VerifyResetCodePage />} />
+                <Route path="reset-password" element={<SetPasswordPage />} />
               </Route>
             </Routes>
           </AuthProvider>

--- a/src/api/auth.api.ts
+++ b/src/api/auth.api.ts
@@ -1,7 +1,9 @@
 import type {
   AuthResponse,
+  ForgotPasswordRequest,
   GoogleLoginRequest,
   LoginRequest,
+  ResetPasswordRequest,
   SendCodeRequest,
   SignUpRequest,
   VerifyEmailRequest,
@@ -21,4 +23,10 @@ export const authApi = {
 
   verifyEmail: (data: VerifyEmailRequest) =>
     apiClient.post<ApiResponse<AuthResponse>>('/auth/verify-email', data),
+
+  forgotPassword: (data: ForgotPasswordRequest) =>
+    apiClient.post<ApiResponse<null>>('/auth/forgot-password', data),
+
+  resetPassword: (data: ResetPasswordRequest) =>
+    apiClient.post<ApiResponse<null>>('/auth/reset-password', data),
 };

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -1,7 +1,13 @@
 import { authApi } from '@/api/auth.api';
 import { useAuthContext } from '@/context/AuthContext';
 import type { ApiResponse } from '@/types/api.types';
-import type { LoginRequest, SignUpRequest, VerifyEmailRequest } from '@/types/auth.types';
+import type {
+  ForgotPasswordRequest,
+  LoginRequest,
+  ResetPasswordRequest,
+  SignUpRequest,
+  VerifyEmailRequest,
+} from '@/types/auth.types';
 import { useMutation } from '@tanstack/react-query';
 import type { AxiosError } from 'axios';
 import { useNavigate } from 'react-router-dom';
@@ -118,6 +124,51 @@ export function useResendCode() {
         error.response?.data?.message ??
         'Failed to resend code';
       toast.error(message);
+    },
+  });
+}
+
+export function useForgotPassword() {
+  const navigate = useNavigate();
+
+  return useMutation({
+    mutationFn: (data: ForgotPasswordRequest) =>
+      authApi.forgotPassword(data).then((response) => response.data),
+    onSuccess: (_response, variables) => {
+      toast.success('A reset code has been sent to your email.');
+      navigate('/verify-reset-code', { state: { email: variables.email } });
+    },
+    onError: (error: AxiosError<ApiResponse<null>>) => {
+      const message =
+        error.response?.data?.errors?.[0] ??
+        error.response?.data?.message ??
+        'Failed to send reset code';
+      toast.error(message);
+    },
+  });
+}
+
+export function useResetPassword() {
+  const navigate = useNavigate();
+
+  return useMutation({
+    mutationFn: (data: ResetPasswordRequest) =>
+      authApi.resetPassword(data).then((response) => response.data),
+    onSuccess: () => {
+      toast.success('Password reset successfully. Please log in.');
+      navigate('/login');
+    },
+    onError: (error: AxiosError<ApiResponse<null>>) => {
+      const status = error.response?.status;
+      const serverMsg = error.response?.data?.errors?.[0] ?? error.response?.data?.message;
+
+      if (status === 410 || serverMsg?.toLowerCase().includes('expired')) {
+        toast.error('Code has expired. Please request a new one.');
+      } else if (status === 400 || serverMsg?.toLowerCase().includes('invalid')) {
+        toast.error('Invalid code. Please check and try again.');
+      } else {
+        toast.error(serverMsg ?? 'Failed to reset password');
+      }
     },
   });
 }

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -70,5 +70,33 @@ export const AUTH_STRINGS = {
     SUBMIT: 'Verify',
     SUBMIT_LOADING: 'Verifying...',
   },
+  FORGOT_PASSWORD: {
+    TITLE: 'Forgot your password?',
+    SUBTITLE: "Don't worry, happens to all of us. Enter your email below to recover your password",
+    BACK_LINK: 'Back to login',
+    EMAIL_PLACEHOLDER: 'Email',
+    SUBMIT: 'Send',
+    SUBMIT_LOADING: 'Sending...',
+    REGISTER_PROMPT: "Don't have an account?",
+    REGISTER_LINK: 'Sign up',
+  },
+  VERIFY_RESET_CODE: {
+    TITLE: 'Check your Email',
+    SUBTITLE: 'A password reset code has been sent to your email.',
+    BACK_LINK: 'Back to login',
+    RESEND_PROMPT: "Didn't receive a code?",
+    RESEND_LINK: 'Resend',
+    SUBMIT: 'Verify',
+    SUBMIT_LOADING: 'Verifying...',
+  },
+  SET_PASSWORD: {
+    TITLE: 'Set a Password',
+    SUBTITLE:
+      'Your previous password has been reseted. Please set a new password for your account.',
+    NEW_PASSWORD_PLACEHOLDER: 'New Password',
+    CONFIRM_PASSWORD_PLACEHOLDER: 'Confirm New Password',
+    SUBMIT: 'Reset password',
+    SUBMIT_LOADING: 'Resetting...',
+  },
   DIVIDER: 'Or',
 } as const;

--- a/src/lib/validators.ts
+++ b/src/lib/validators.ts
@@ -43,3 +43,36 @@ export const signUpSchema = z
   });
 
 export type SignUpFormData = z.infer<typeof signUpSchema>;
+
+// ─── Forgot Password ─────────────────────────────────────────
+// Mirrors: ForgotPasswordDtoValidator in backend
+export const forgotPasswordSchema = z.object({
+  email: z
+    .string()
+    .min(1, 'Email is required')
+    .email('Invalid email format')
+    .max(256, 'Email cannot exceed 256 characters'),
+});
+
+export type ForgotPasswordFormData = z.infer<typeof forgotPasswordSchema>;
+
+// ─── Reset Password ──────────────────────────────────────────
+// Mirrors: ResetPasswordDtoValidator in backend
+export const resetPasswordSchema = z
+  .object({
+    newPassword: z
+      .string()
+      .min(8, 'Password must be at least 8 characters')
+      .max(100, 'Password cannot exceed 100 characters')
+      .regex(/[A-Z]/, 'Must contain at least one uppercase letter')
+      .regex(/[a-z]/, 'Must contain at least one lowercase letter')
+      .regex(/[0-9]/, 'Must contain at least one number')
+      .regex(/[\W_]/, 'Must contain at least one special character'),
+    confirmPassword: z.string().min(1, 'Confirm password is required'),
+  })
+  .refine((data) => data.newPassword === data.confirmPassword, {
+    message: 'Passwords do not match',
+    path: ['confirmPassword'],
+  });
+
+export type ResetPasswordFormData = z.infer<typeof resetPasswordSchema>;

--- a/src/pages/auth/ForgotPasswordPage.tsx
+++ b/src/pages/auth/ForgotPasswordPage.tsx
@@ -1,0 +1,92 @@
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { Link } from 'react-router-dom';
+import { AuthPageLayout } from '@/components/layout/AuthPageLayout';
+import { GlassCard } from '@/components/shared/GlassCard';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { useForgotPassword } from '@/hooks/useAuth';
+import { forgotPasswordSchema, type ForgotPasswordFormData } from '@/lib/validators';
+import { AUTH_ICONS, AUTH_STRINGS } from '@/lib/constants';
+
+export function ForgotPasswordPage() {
+  const { mutate: forgotPassword, isPending } = useForgotPassword();
+
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<ForgotPasswordFormData>({
+    resolver: zodResolver(forgotPasswordSchema),
+  });
+
+  const onSubmit = (data: ForgotPasswordFormData) => {
+    forgotPassword(data);
+  };
+
+  return (
+    <AuthPageLayout>
+      <GlassCard className="relative z-10 flex w-full flex-col items-center justify-center gap-8 sm:gap-10">
+        {/* Header */}
+        <div className="flex w-full flex-col items-center gap-4">
+          <Link
+            to="/login"
+            className="inline-flex w-full items-center gap-1 text-sm font-medium text-[#313131] transition-colors hover:text-black"
+          >
+            <img src="/assets/chevron_back.svg" alt="" aria-hidden="true" className="size-6" />
+            {AUTH_STRINGS.FORGOT_PASSWORD.BACK_LINK}
+          </Link>
+          <h1 className="text-3xl sm:text-[40px] sm:leading-tight font-bold text-[#24252C] text-center">
+            {AUTH_STRINGS.FORGOT_PASSWORD.TITLE}
+          </h1>
+          <p className="w-full text-center text-sm sm:text-base font-normal text-[#313131]">
+            {AUTH_STRINGS.FORGOT_PASSWORD.SUBTITLE}
+          </p>
+        </div>
+
+        {/* Form */}
+        <form onSubmit={handleSubmit(onSubmit)} className="flex w-full flex-col gap-8">
+          <div className="space-y-1">
+            <div className="relative">
+              <img
+                src={AUTH_ICONS.EMAIL}
+                alt=""
+                aria-hidden="true"
+                className="absolute left-4 top-1/2 -translate-y-1/2 size-5"
+              />
+              <Input
+                id="email"
+                type="email"
+                placeholder={AUTH_STRINGS.FORGOT_PASSWORD.EMAIL_PLACEHOLDER}
+                className="h-14 rounded-lg border-0 border-b border-muted-foreground/30 bg-transparent pl-12 shadow-none focus-visible:ring-0 focus-visible:border-brand-500"
+                {...register('email')}
+                aria-invalid={!!errors.email}
+              />
+            </div>
+            {errors.email && (
+              <p className="text-caption text-destructive">{errors.email.message}</p>
+            )}
+          </div>
+
+          <Button
+            type="submit"
+            disabled={isPending}
+            className="h-[50px] w-full rounded-xl bg-[#824892] text-center text-base font-semibold text-white hover:bg-[#6f3a80]"
+          >
+            {isPending
+              ? AUTH_STRINGS.FORGOT_PASSWORD.SUBMIT_LOADING
+              : AUTH_STRINGS.FORGOT_PASSWORD.SUBMIT}
+          </Button>
+        </form>
+
+        {/* Footer */}
+        <p className="text-center text-sm text-muted-foreground">
+          {AUTH_STRINGS.FORGOT_PASSWORD.REGISTER_PROMPT}{' '}
+          <Link to="/register" className="font-semibold text-brand-500 hover:text-brand-600">
+            {AUTH_STRINGS.FORGOT_PASSWORD.REGISTER_LINK}
+          </Link>
+        </p>
+      </GlassCard>
+    </AuthPageLayout>
+  );
+}

--- a/src/pages/auth/SetPasswordPage.tsx
+++ b/src/pages/auth/SetPasswordPage.tsx
@@ -1,0 +1,135 @@
+import { useState } from 'react';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { Navigate, useLocation } from 'react-router-dom';
+import { Eye, EyeOff } from 'lucide-react';
+import { AuthPageLayout } from '@/components/layout/AuthPageLayout';
+import { GlassCard } from '@/components/shared/GlassCard';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { useResetPassword } from '@/hooks/useAuth';
+import { resetPasswordSchema, type ResetPasswordFormData } from '@/lib/validators';
+import { AUTH_ICONS, AUTH_STRINGS } from '@/lib/constants';
+
+export function SetPasswordPage() {
+  const location = useLocation();
+  const state = location.state as { email?: string; code?: string } | null;
+  const email = state?.email;
+  const code = state?.code;
+
+  const [showNewPassword, setShowNewPassword] = useState(false);
+  const [showConfirmPassword, setShowConfirmPassword] = useState(false);
+
+  const { mutate: resetPassword, isPending } = useResetPassword();
+
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<ResetPasswordFormData>({
+    resolver: zodResolver(resetPasswordSchema),
+  });
+
+  // Missing email or code → restart the flow
+  if (!email || !code) return <Navigate to="/forgot-password" replace />;
+
+  const onSubmit = (data: ResetPasswordFormData) => {
+    resetPassword({
+      email,
+      code,
+      newPassword: data.newPassword,
+      confirmPassword: data.confirmPassword,
+    });
+  };
+
+  return (
+    <AuthPageLayout>
+      <GlassCard className="relative z-10 flex w-full flex-col items-center justify-center gap-8 sm:gap-10">
+        {/* Header */}
+        <div className="flex w-full flex-col items-center gap-4">
+          <h1 className="text-3xl sm:text-[40px] sm:leading-tight font-bold text-[#24252C] text-center">
+            {AUTH_STRINGS.SET_PASSWORD.TITLE}
+          </h1>
+          <p className="w-full text-center text-sm sm:text-base font-normal text-[#313131]">
+            {AUTH_STRINGS.SET_PASSWORD.SUBTITLE}
+          </p>
+        </div>
+
+        {/* Form */}
+        <form onSubmit={handleSubmit(onSubmit)} className="flex w-full flex-col gap-8">
+          {/* New Password */}
+          <div className="space-y-1">
+            <div className="relative">
+              <img
+                src={AUTH_ICONS.PASSWORD}
+                alt=""
+                aria-hidden="true"
+                className="absolute left-4 top-1/2 -translate-y-1/2 size-5"
+              />
+              <Input
+                id="newPassword"
+                type={showNewPassword ? 'text' : 'password'}
+                placeholder={AUTH_STRINGS.SET_PASSWORD.NEW_PASSWORD_PLACEHOLDER}
+                className="h-14 rounded-lg border-0 border-b border-muted-foreground/30 bg-transparent pl-12 pr-12 shadow-none focus-visible:ring-0 focus-visible:border-brand-500"
+                {...register('newPassword')}
+                aria-invalid={!!errors.newPassword}
+              />
+              <button
+                type="button"
+                className="absolute right-4 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
+                onClick={() => setShowNewPassword(!showNewPassword)}
+                aria-label={showNewPassword ? 'Hide password' : 'Show password'}
+              >
+                {showNewPassword ? <Eye className="size-5" /> : <EyeOff className="size-5" />}
+              </button>
+            </div>
+            {errors.newPassword && (
+              <p className="text-caption text-destructive">{errors.newPassword.message}</p>
+            )}
+          </div>
+
+          {/* Confirm Password */}
+          <div className="space-y-1">
+            <div className="relative">
+              <img
+                src={AUTH_ICONS.PASSWORD}
+                alt=""
+                aria-hidden="true"
+                className="absolute left-4 top-1/2 -translate-y-1/2 size-5"
+              />
+              <Input
+                id="confirmPassword"
+                type={showConfirmPassword ? 'text' : 'password'}
+                placeholder={AUTH_STRINGS.SET_PASSWORD.CONFIRM_PASSWORD_PLACEHOLDER}
+                className="h-14 rounded-lg border-0 border-b border-muted-foreground/30 bg-transparent pl-12 pr-12 shadow-none focus-visible:ring-0 focus-visible:border-brand-500"
+                {...register('confirmPassword')}
+                aria-invalid={!!errors.confirmPassword}
+              />
+              <button
+                type="button"
+                className="absolute right-4 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
+                onClick={() => setShowConfirmPassword(!showConfirmPassword)}
+                aria-label={showConfirmPassword ? 'Hide password' : 'Show password'}
+              >
+                {showConfirmPassword ? <Eye className="size-5" /> : <EyeOff className="size-5" />}
+              </button>
+            </div>
+            {errors.confirmPassword && (
+              <p className="text-caption text-destructive">{errors.confirmPassword.message}</p>
+            )}
+          </div>
+
+          <Button
+            type="submit"
+            disabled={isPending}
+            className="h-12 w-full rounded-xl bg-[#824892] text-center text-base font-semibold text-white hover:bg-[#6f3a80]"
+          >
+            {isPending
+              ? AUTH_STRINGS.SET_PASSWORD.SUBMIT_LOADING
+              : AUTH_STRINGS.SET_PASSWORD.SUBMIT}
+          </Button>
+        </form>
+      </GlassCard>
+    </AuthPageLayout>
+  );
+}

--- a/src/pages/auth/VerifyResetCodePage.tsx
+++ b/src/pages/auth/VerifyResetCodePage.tsx
@@ -1,0 +1,115 @@
+import { OtpInput } from '@/components/shared/OtpInput';
+import { GlassCard } from '@/components/shared/GlassCard';
+import { AuthPageLayout } from '@/components/layout/AuthPageLayout';
+import { Button } from '@/components/ui/button';
+import { useForgotPassword } from '@/hooks/useAuth';
+import { AUTH_STRINGS } from '@/lib/constants';
+import { useEffect, useState } from 'react';
+import { Link, Navigate, useLocation, useNavigate } from 'react-router-dom';
+
+const RESEND_COOLDOWN = 60; // seconds
+const COOLDOWN_KEY = 'reset_code_cooldown_end';
+
+export function VerifyResetCodePage() {
+  const location = useLocation();
+  const navigate = useNavigate();
+  const state = location.state as { email?: string } | null;
+  const email = state?.email;
+
+  const [otp, setOtp] = useState('');
+  const [cooldown, setCooldown] = useState(() => {
+    const stored = sessionStorage.getItem(COOLDOWN_KEY);
+    if (stored) {
+      const remaining = Math.ceil((Number(stored) - Date.now()) / 1000);
+      return remaining > 0 ? remaining : 0;
+    }
+    return RESEND_COOLDOWN;
+  });
+
+  const { mutate: resendCode, isPending: isResending } = useForgotPassword();
+
+  useEffect(() => {
+    if (cooldown <= 0) {
+      sessionStorage.removeItem(COOLDOWN_KEY);
+      return;
+    }
+    const timer = setInterval(() => setCooldown((prev) => prev - 1), 1000);
+    return () => clearInterval(timer);
+  }, [cooldown]);
+
+  // No email in state → go to forgot-password
+  if (!email) return <Navigate to="/forgot-password" replace />;
+
+  const handleVerify = () => {
+    if (otp.length !== 6) return;
+    // No backend verify step — carry email+code to the reset-password screen
+    navigate('/reset-password', { state: { email, code: otp } });
+  };
+
+  const handleResend = () => {
+    if (cooldown > 0 || isResending) return;
+    resendCode({ email });
+    setCooldown(RESEND_COOLDOWN);
+    sessionStorage.setItem(COOLDOWN_KEY, String(Date.now() + RESEND_COOLDOWN * 1000));
+    setOtp('');
+  };
+
+  const maskedEmail = email.replace(
+    /^(.{1,2})(.*)(@.*)$/,
+    (_, start, _mid, end) => `${start}${'*'.repeat(4)}${end}`
+  );
+
+  return (
+    <AuthPageLayout>
+      <GlassCard className="relative z-10 flex w-full flex-col items-center justify-center gap-8 sm:gap-10">
+        {/* Header */}
+        <div className="flex w-full flex-col items-center gap-4">
+          <Link
+            to="/login"
+            className="inline-flex w-full items-center gap-1 text-sm font-medium text-[#313131] transition-colors hover:text-black"
+          >
+            <img src="/assets/chevron_back.svg" alt="" aria-hidden="true" className="size-6" />
+            {AUTH_STRINGS.VERIFY_RESET_CODE.BACK_LINK}
+          </Link>
+          <h1 className="text-3xl sm:text-[40px] sm:leading-tight font-bold text-[#24252C] text-center">
+            {AUTH_STRINGS.VERIFY_RESET_CODE.TITLE}
+          </h1>
+          <p className="w-full text-center text-sm sm:text-base font-normal text-[#313131]">
+            {AUTH_STRINGS.VERIFY_RESET_CODE.SUBTITLE}{' '}
+            <span className="font-medium">{maskedEmail}</span>
+          </p>
+        </div>
+
+        {/* OTP input + Resend */}
+        <div className="flex w-full flex-col items-center gap-4 sm:items-start">
+          <OtpInput value={otp} onChange={setOtp} onSubmit={handleVerify} />
+
+          <p className="w-full text-sm font-medium text-[#313131]">
+            {AUTH_STRINGS.VERIFY_RESET_CODE.RESEND_PROMPT}{' '}
+            {cooldown > 0 ? (
+              <span className="font-semibold text-[#883dbd]">Resend in {cooldown}s</span>
+            ) : (
+              <button
+                type="button"
+                onClick={handleResend}
+                disabled={isResending}
+                className="font-semibold text-[#883dbd] transition-colors hover:text-[#6a0dad] disabled:opacity-50"
+              >
+                {AUTH_STRINGS.VERIFY_RESET_CODE.RESEND_LINK}
+              </button>
+            )}
+          </p>
+        </div>
+
+        {/* Verify button */}
+        <Button
+          onClick={handleVerify}
+          disabled={otp.length !== 6}
+          className="h-[50px] w-full rounded-xl bg-[#824892] text-center text-base font-semibold text-white hover:bg-[#6f3a80]"
+        >
+          {AUTH_STRINGS.VERIFY_RESET_CODE.SUBMIT}
+        </Button>
+      </GlassCard>
+    </AuthPageLayout>
+  );
+}

--- a/src/types/auth.types.ts
+++ b/src/types/auth.types.ts
@@ -47,3 +47,15 @@ export interface VerifyEmailRequest {
   email: string;
   code: string;
 }
+
+// ─── Forgot / Reset Password ─────────────────────────────────
+export interface ForgotPasswordRequest {
+  email: string;
+}
+
+export interface ResetPasswordRequest {
+  email: string;
+  code: string;
+  newPassword: string;
+  confirmPassword: string;
+}


### PR DESCRIPTION
## Overview
Implements the full forgot-password journey on the web app, wiring up the existing backend endpoints (`POST /auth/forgot-password`, `POST /auth/reset-password`) into a 3-step UX that matches the Figma designs.

## Flow
1. **`/forgot-password`** — user enters their email → `POST /auth/forgot-password` sends an OTP by email.
2. **`/verify-reset-code`** — user enters the 6-digit code (OTP input + 60s resend cooldown persisted in `sessionStorage`). On success, hands off `{ email, code }` via route state.
3. **`/reset-password`** — user sets a new password (new + confirm, with show/hide toggles) → `POST /auth/reset-password`. On success, toast + redirect to `/login`.

Guards: `/verify-reset-code` and `/reset-password` redirect back to `/forgot-password` if required route state is missing.

## Changes
- **Types & API**: `ForgotPasswordRequest`, `ResetPasswordRequest` + `authApi.forgotPassword`, `authApi.resetPassword`.
- **Hooks**: `useForgotPassword`, `useResetPassword` (react-query mutations, sonner toasts, error handling for 400/410 codes).
- **Validation**: `forgotPasswordSchema`, `resetPasswordSchema` (mirrors backend rules: 8+ chars, upper/lower/digit/special, matches confirm).
- **Strings**: `AUTH_STRINGS.FORGOT_PASSWORD`, `VERIFY_RESET_CODE`, `SET_PASSWORD`.
- **Pages**: `ForgotPasswordPage`, `VerifyResetCodePage`, `SetPasswordPage`.
- **Routes**: registered `/forgot-password`, `/verify-reset-code`, `/reset-password` inside `AppLayout`.


## Testing
- [x] Request code for existing user → email received, toast shown, navigates to verify step.
- [x] Request code for unknown email → same success toast (no enumeration leak).
- [x] Enter wrong OTP → backend rejects at reset step with "invalid code" toast.
- [x] Expired code (410) → "code expired" toast, user can resend.
- [x] Password mismatch → client-side validation error.
- [x] Weak password → client-side validation error (matches backend rules).
- [x] Successful reset → redirected to `/login`, can sign in with new password.
- [x] Direct nav to `/verify-reset-code` or `/reset-password` without state → redirects to `/forgot-password`.
- [x] Resend cooldown persists across refresh within 60s.